### PR TITLE
Adds nodemon to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ignore-styles": "^5.0.1",
     "jsdom": "9.12.0",
     "mocha": "^3.3.0",
+    "nodemon": "^1.12.1",
     "nyc": "^11.2.1",
     "react-hot-loader": "^1.3.1",
     "react-test-renderer": "16",


### PR DESCRIPTION
This fixes a bug where `nodemon` is not included in `devDependencies` making it impossible to run `yarn start:dev`