### PR TITLE
Separate stores for server and client

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -1,19 +1,18 @@
-const defaults = require('./defaults')
-const webpack = require('webpack')
-const path = require('path');
+const defaults = require('./defaults');
+const webpack = require('webpack');
 
 const devEntry = [
   'webpack/hot/dev-server',
   'webpack-hot-middleware/client',
   ...defaults.entry,
-]
+];
 
 const plugins = [
   ...defaults.plugins,
   new webpack.HotModuleReplacementPlugin(),
   new webpack.NoEmitOnErrorsPlugin(),
 
-]
+];
 
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
@@ -29,4 +28,4 @@ module.exports = {
   module: defaults.module,
 
   plugins,
-}
+};

--- a/decls/serialize-javascript.js
+++ b/decls/serialize-javascript.js
@@ -1,0 +1,3 @@
+declare module 'serialize-javascript' {
+  declare export default function serialize({} | empty | void) : string;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "React App Boilerplate",
   "main": "src/index.js",
   "repository": "git@github.com:cloverinteractive/boilerplate.git",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "resolve-url-loader": "^2.1.0",
     "semantic-ui-css": "2.2.12",
     "semantic-ui-react": "0.77.1",
+    "serialize-javascript": "^1.4.0",
     "style-loader": "0.19.0",
     "url-loader": "^0.6.2",
     "uuid": "^3.1.0",

--- a/spec/server/store-spec.js
+++ b/spec/server/store-spec.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import store from 'server/store';
+
+describe('store', () => {
+  context('server rendering', () => {
+    it('responds to getState', () => {
+      expect(store.getState).to.exist;
+    });
+
+    it('returns a default state', () => {
+      const state = store.getState();
+
+      expect(state).to.exist
+      expect(state).to.not.eql({});
+    });
+
+    it('responds to dispatch', () => {
+      expect(store.dispatch).to.exist;
+    });
+  });
+});

--- a/spec/store-spec.js
+++ b/spec/store-spec.js
@@ -41,29 +41,4 @@ describe('store', () => {
             expect(canLoadDevTools()).to.not.throw();
         })
     });
-
-    context('server rendering', () => {
-        beforeEach(() => {
-            global.window = undefined;
-            const store = require('store');
-
-            history = store.history;
-            canLoadDevTools = store.canLoadDevTools();
-        });
-
-        afterEach(() => {
-            global.window = global.document.defaultView
-            delete require.cache[require.resolve('store')];
-        })
-
-        it('sets history blank when rendered from server', () => {
-            expect(window).to.not.exist;
-            expect(history).to.eql({});
-        });
-
-        it('safely ignores redux-devtools-extension when not present', () => {
-            expect(window).to.not.exist;
-            expect(canLoadDevTools()).to.not.throw();
-        })
-    });
 })

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Routes from 'routes';
+import Router from 'router';
 
-ReactDOM.hydrate(<Routes />, document.getElementById('app'));
+ReactDOM.hydrate(<Router />, document.getElementById('app'));

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,0 +1,14 @@
+
+import React from 'react';
+import { ConnectedRouter as Router } from 'react-router-redux';
+import store, { history } from 'store';
+import { Provider } from 'react-redux';
+import Routes from 'routes';
+
+export default () => (
+  <Provider store={store}>
+    <Router history={history}>
+      <Routes />
+    </Router>
+  </Provider>
+);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import { ConnectedRouter as Router } from 'react-router-redux';
 import { Route, Switch } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import store, { history } from 'store';
-
 import Main from 'main';
 import Pages from 'pages';
 
 import './css/global.css';
 
-export const App = () => (
+export default () => (
   <div className="wrapper">
     <Main.Header />
     <Switch>
@@ -19,13 +15,3 @@ export const App = () => (
     </Switch>
   </div>
 );
-
-const Routes = () => (
-  <Provider store={store}>
-    <Router history={history}>
-      <App />
-    </Router>
-  </Provider>
-);
-
-export default Routes;

--- a/src/server/helpers/renderer.js
+++ b/src/server/helpers/renderer.js
@@ -2,10 +2,15 @@
 
 import { renderToString } from 'react-dom/server';
 import { Helmet } from 'react-helmet';
+import serialize from 'serialize-javascript';
 
 const isDevelop: boolean = process.env.NODE_ENV !== 'production';
 
-export default (Component: React$Element<any>): string => {
+type Store = {
+  getState: () => {} | empty | void,
+};
+
+export default (Component: React$Element<any>, store: Store): string => {
   const content = renderToString(Component);
   const helmet = Helmet.renderStatic();
   const styles = isDevelop ? '' : '<link rel="stylesheet" href="/styles.css">';
@@ -22,6 +27,9 @@ export default (Component: React$Element<any>): string => {
       </head>
       <body>
         <div id="app">${content}</div>
+        <script>
+          window.INITIAL_STATE = ${serialize(store.getState())};
+        </script>
         <script async src="/bundle.js"></script>
       </body>
     </html>`;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,8 +1,8 @@
 // @flow
 
 import express from 'express';
-import StaticRouter from './routes';
-import devServer from './env/development';
+import devServer from 'server/env/development';
+import StaticRouter from 'server/routes';
 
 const isDeveloping: boolean = process.env.NODE_ENV !== 'production';
 const port: number = parseInt(process.env.PORT, 10) || 8080;

--- a/src/server/routes.jsx
+++ b/src/server/routes.jsx
@@ -1,11 +1,11 @@
 // @flow
 
 import React from 'react';
-import { App } from 'routes';
+import Routes from 'routes';
 import { StaticRouter } from 'react-router';
 import { Provider } from 'react-redux';
-import store from 'store';
 import render from 'server/helpers/renderer';
+import store from 'server/store';
 
 type Props = {
   context: Object,
@@ -15,7 +15,7 @@ type Props = {
 const SSR = ({ context, location }: Props) => (
   <Provider store={store}>
     <StaticRouter context={context} location={location}>
-      <App />
+      <Routes />
     </StaticRouter>
   </Provider>
 );
@@ -23,5 +23,5 @@ const SSR = ({ context, location }: Props) => (
 export default (req: express$Request, res: express$Response) => {
   const context = {};
 
-  res.send(render(<SSR context={context} location={req.url} />));
+  res.send(render(<SSR context={context} location={req.url} />, store));
 };

--- a/src/server/store.js
+++ b/src/server/store.js
@@ -1,0 +1,9 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import rootReducer from 'root-reducer';
+
+const defaultState = {};
+const enhancers = applyMiddleware(thunkMiddleware);
+const store = createStore(rootReducer, defaultState, enhancers);
+
+export default store;

--- a/src/store.js
+++ b/src/store.js
@@ -4,17 +4,17 @@ import { routerMiddleware } from 'react-router-redux';
 import createHistory from 'history/createBrowserHistory';
 import rootReducer from './root-reducer';
 
-const defaultState = {};
+const defaultState = window.INITIAL_STATE;
 
 export const canLoadDevTools = () => {
-  if (process.env.NODE_ENV !== 'production' && typeof window === 'object' && window.devToolsExtension) {
+  if (process.env.NODE_ENV !== 'production' && typeof window.devToolsExtension === 'function') {
     return window.devToolsExtension();
   }
 
   return compose;
 };
 
-export const history = typeof window === 'object' ? createHistory() : {};
+export const history = createHistory();
 const routeMiddleware = routerMiddleware(history);
 
 const enhancers = compose(applyMiddleware(routeMiddleware, thunkMiddleware), canLoadDevTools());

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -1,16 +1,6 @@
-const PRODUCTION = 'production'
-const DEVELOPMENT = 'development'
+const prodConfig = require('./config/production');
+const devConfig = require('./config/development');
 
-let config = {}
+const PRODUCTION = 'production';
 
-switch (process.env.NODE_ENV) {
-  case PRODUCTION:
-    config = require('./config/production.js')
-    break
-
-  case DEVELOPMENT:
-  default:
-    config = require('./config/development.js')
-}
-
-module.exports = config
+module.exports = process.env.NODE_ENV === PRODUCTION ? prodConfig : devConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7950,6 +7950,10 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
+serialize-javascript@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"


### PR DESCRIPTION
- [x] Create a separate store for server and client
- [x] Remove all `window` safe guards from client store
- [x] Make more consistent server store spec
- [x] Improve server bundle by separating `<Routes />` from `<Router />`
- [x] Remove the need for `let` in `webpack.client.js`

Rel: #16 