### PR TITLE
Fix Express status codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "React App Boilerplate",
   "main": "src/index.js",
   "repository": "git@github.com:cloverinteractive/boilerplate.git",

--- a/src/pages/components/Error500.jsx
+++ b/src/pages/components/Error500.jsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+
+const Error500 = () => (
+  <div className="container is-fluid">
+    <h1 className="title">Something</h1>
+    <div className="content">
+      <p>Something went wrong with the operation you tried, please try again later</p>
+    </div>
+    <Helmet>
+      <title>Something went wrong</title>
+    </Helmet>
+  </div>
+);
+
+export default Error500;

--- a/src/pages/components/Error500.test.jsx
+++ b/src/pages/components/Error500.test.jsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import Error500 from './Error500';
+
+describe('<Error500 />', () => {
+  test('it renders correctly', () => {
+    const tree = renderer
+      .create(<Error500 />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/pages/components/__snapshots__/Error500.test.jsx.snap
+++ b/src/pages/components/__snapshots__/Error500.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Error500 /> it renders correctly 1`] = `
+<div
+  className="container is-fluid"
+>
+  <h1
+    className="title"
+  >
+    Something
+  </h1>
+  <div
+    className="content"
+  >
+    <p>
+      Something went wrong with the operation you tried, please try again later
+    </p>
+  </div>
+</div>
+`;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -5,20 +5,29 @@ import Messages from './components/Messages';
 import Nav from './components/Nav.bs';
 import './css/bulma.scss';
 
-export default () => (
+export const routes = [
+  { path: '/', exact: true, component: Pages.Home },
+  { path: '/about', component: Pages.About },
+];
+
+/* eslint-disable react/jsx-props-no-spreading */
+export default ({ children }) => (
   <div className="wrapper">
     <Nav />
     <Messages />
     <Switch>
-      <Route exact path="/">
-        <Pages.Home />
-      </Route>
-      <Route path="/about">
-        <Pages.About />
-      </Route>
-      <Route>
-        <Pages.Error404 />
-      </Route>
+      {routes.map(({
+        path, exact, component: C, ...rest
+      }) => (
+        <Route
+          key={path}
+          path={path}
+          exact={exact}
+          render={(props) => <C {...props} {...rest} />}
+        />
+      ))}
+      {children}
+      <Route render={(props) => <Pages.Error404 {...props} />} />
     </Switch>
   </div>
 );

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -6,8 +6,15 @@ import Nav from './components/Nav.bs';
 import './css/bulma.scss';
 
 export const routes = [
-  { path: '/', exact: true, component: Pages.Home },
-  { path: '/about', component: Pages.About },
+  {
+    path: '/',
+    exact: true,
+    component: Pages.Home,
+  },
+  {
+    path: '/about',
+    component: Pages.About,
+  },
 ];
 
 /* eslint-disable react/jsx-props-no-spreading */

--- a/src/server/helpers/renderer.js
+++ b/src/server/helpers/renderer.js
@@ -1,10 +1,12 @@
 import { renderToString } from 'react-dom/server';
 import { Helmet } from 'react-helmet';
 import serialize from 'serialize-javascript';
+import { isDevelopment } from './env-access';
 
 export default (Component, store) => {
   const content = renderToString(Component);
   const helmet = Helmet.renderStatic();
+  const staticStyles = isDevelopment ? '' : '<link rel="stylesheet" href="/styles.css">';
 
   const template = `<!doctype html>
     <html lang="en-US" class="has-navbar-fixed-top">
@@ -14,7 +16,7 @@ export default (Component, store) => {
         ${helmet.link.toString()}
         ${helmet.title.toString()}
         ${helmet.meta.toString()}
-        <link rel="stylesheet" href="/styles.css">
+        ${staticStyles}
         <script src="/vendors.js"></script>
       </head>
       <body>

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import StaticRouter from 'server/routes';
+import StaticRouter, { errorHandler } from 'server/routes';
 import { isDevelopment } from 'server/helpers/env-access';
 import dotEnv from 'dotenv';
 
@@ -17,11 +17,10 @@ if (isDevelopment) {
 }
 
 app.get('*', StaticRouter);
+app.use(errorHandler);
 
-app.listen(port, '0.0.0.0', (err) => {
+app.listen(port, '0.0.0.0', () => {
   /* eslint-disable no-console */
-  if (err) console.error(err);
-
   console.info('Listening on port %s. Open up http://localhost:%s/ in your browser.', port, port);
   /* eslint-enable no-console */
 });

--- a/src/server/routes.jsx
+++ b/src/server/routes.jsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import Routes, { routes } from 'routes';
-import { StaticRouter, Route, matchPath } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import render from 'server/helpers/renderer';
-import store from 'server/store';
+import { StaticRouter, Route, matchPath } from 'react-router-dom';
+import render from './helpers/renderer';
+import store from './store';
 import Error500 from '../pages/components/Error500';
 
 const SSR = ({ context, location }) => (
@@ -36,10 +36,13 @@ export const errorHandler = (error, _, res) => {
 export default
 async (req, res, next) => {
   try {
-    const activeRoute = routes.find((route) => matchPath(req.url, route));
-    const loadData = activeRoute && activeRoute.loadData;
-    const context = await loadData && loadData();
-    const status = !activeRoute ? 404 : 200;
+    const activeRoute = routes.find((route) => matchPath(req.url, route)) || {};
+
+    const context = await activeRoute.loadData
+      ? activeRoute.loadData(req.path)
+      : Promise.resolve();
+
+    const status = !activeRoute.path ? 404 : 200;
 
     res
       .status(status)


### PR DESCRIPTION
Up until today express had always responed with 200, this updated fixes this.

Routes are now shape as an array of objects, one of the new supported properties is a `loadData` function which if present will be called and any resulting data will be sent down to the component as part of the router context.

- [x] Respond either 200, 404 or 500 special cases will need to be implemented.
- [x] Add a way to add async calls in SSR for components that rely on external data.

fixes: #16