### PR TITLE
Add simple way to run dockerized

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+lib
+__tests__
+.merlin
+core
+build
+public
+.bsb.lock
+npm-debug.log
+coverage
+*.bs.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ public/*
 .bsb.lock
 core
 npm-debug.log
-/lib/bs/
+lib
 .nyc_output
 yarn-error.log
 coverage

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM node:stretch
+
+EXPOSE 8080
+
+WORKDIR /opt/src
+
+COPY package.json .
+COPY package-lock.json .
+
+RUN apt-get update
+RUN apt-get install build-essential -y
+RUN npm install --ignore-engines
+
+CMD ["npm" "start"]
+
+# vim: set ft=dockerfile:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ npm run start:prod # Run in production mode
 
 ## Running in Docker
 
+### Development
+
+You may want to do all your development in docker and keep dependencies locked for the whole team, we
+added a `Dockerfile.dev` and `docker-compose.yml` so you can build one and run many instances:
+
+```sh
+docker-compose build
+docker-compose up
+```
+
+Application will be proxied by `nginx` you can browse the app at `http://localhost/`, you can turn the app
+off by running:
+
+```sh
+docker-compose down
+```
+
+### Production
+
 Another way to run the app in production is to use docker just try the following:
 
 ```sh

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,18 @@
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name web.dev;
+
+  location / {
+    resolver web valid=30s;
+    proxy_pass http://web:8080/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+  }
+}
+
+# vim: set ft=nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.1"
+services:
+  proxy:
+    image: "nginx:alpine"
+    command: ["nginx", "-g", "daemon off;"]
+    ports:
+      - 80:80
+    environment:
+      - NGINX_HOST=web.dev
+      - NGINX_PORT=80
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - web
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: "npm start"
+    image: "web-dev:dev"
+    volumes:
+      - ./:/opt/src


### PR DESCRIPTION
Besides of adding a production `Dockerfile` this adds enough `docker-compose` to run this in development proxied via `nginx` and updates the `README`